### PR TITLE
feat: update the bootstrap version to v2.22.0

### DIFF
--- a/src/commands/aqua.yml
+++ b/src/commands/aqua.yml
@@ -130,16 +130,19 @@ steps:
         if [ "$OS" = windows ]; then
           install_path=${AQUA_ROOT_DIR:-$HOME/AppData/Local/aquaproj-aqua}/bin/aqua.exe
         fi
-        
-        bootstrap_version=v2.9.1
-        checksums="0ad1ec9b0f9250039f8c5c90a7e73a0b2c55ac904c5904742d47805d1c3a2654  aqua_linux_arm64.tar.gz
-        674866ea9d925bb033d0fceaa1fd3a0890c84f035db2a6f00782b8cd0638cea2  aqua_windows_arm64.tar.gz
-        a87952cc7b3520346aa0887476465d03ca6e57c2f06bfa116707cc3bf50b3eaa  aqua_darwin_arm64.tar.gz
-        c6bdc60187b7e5a703ab03d47e310aef91c776cefc0c136ecc9b9a27be258051  aqua_linux_amd64.tar.gz
-        e69869d5de833fe8de6b196e592b7f10ee47c24316cd440e3c2d6506114fc2f0  aqua_darwin_amd64.tar.gz
-        f58824ca851f023494e824c43b1516da5296235bd376446f13353fbbfa1b4f14  aqua_windows_amd64.tar.gz"
+
+        bootstrap_version=v2.22.0
+        checksums="e66e19c3cb2da10ddeb8dfd5dc523d909e0fba87fa1337db017160fba3d90414  aqua_darwin_amd64.tar.gz
+        493ab58b6b93bea2a9b9a144cac8aea90213f88b484d3de27352a2c5fb9b90e2  aqua_darwin_arm64.tar.gz
+        b63d596a352d1c197c8e99342b2618a71f0ce4d6683a16578d0f2a8b2963212d  aqua_linux_amd64.tar.gz
+        3b3632bfdf0527483c6219553acc4ca5b0cdceb7362f61ae4d1e2f7f77fbf6a6  aqua_linux_arm64.tar.gz
+        c890463c89c6349c9e6d675ce7b8d121070bd489f78f4b68e5cbf02e4355f240  aqua_windows_amd64.zip
+        b9d657a6d64ae70ddf03c296a4563526dd34d2f911cf1b62a0a708aebab11b41  aqua_windows_arm64.zip"
         
         filename=aqua_${OS}_${ARCH}.tar.gz
+        if [ "$OS" = windows ]; then
+        	filename=aqua_${OS}_${ARCH}.zip
+        fi
         URL=https://github.com/aquaproj/aqua/releases/download/$bootstrap_version/$filename
         
         tempdir=$(mktemp -d)


### PR DESCRIPTION
Basically a port of aquaproj/aqua-installer/pull/580 to circleci orbs