### PR TITLE
feat: re-enable Cosign and slsa-verifier

### DIFF
--- a/src/commands/aqua.yml
+++ b/src/commands/aqua.yml
@@ -132,13 +132,13 @@ steps:
           install_path=${AQUA_ROOT_DIR:-$HOME/AppData/Local/aquaproj-aqua}/bin/aqua.exe
         fi
 
-        bootstrap_version=v2.25.1-5
-        checksums="26b89ce022795b25e342f14d2ee1cdacdde0d57d1650b403e48938b917d84645  aqua_darwin_amd64.tar.gz
-        e9a59d4ce33327f72027786c39f2b60ba33683cf89fc48e6231beaf482b59e6d  aqua_darwin_arm64.tar.gz
-        bcb35348205f572bfb310e0cc9bd5279166754447e83acec17de9b289bf0c2a1  aqua_linux_amd64.tar.gz
-        8ff03737b43ed63bc9bccb36c5957fff62f93f23f18d523bf715e3b5732a3eb9  aqua_linux_arm64.tar.gz
-        10d8662b13531d3c04f295ab65808a0fa4a629af453444159659dc318ea3f0f8  aqua_windows_amd64.zip
-        88b50806832d7a0ded5cbc4d2eca9c22f9e19e06ef2f7ce76a47fbd8f0be7ce8  aqua_windows_arm64.zip"
+        bootstrap_version=v2.25.1
+        checksums="791df099b6491a212ac5996580c6851fa1fa843c430160cf897b5cee4d49cd67  aqua_darwin_amd64.tar.gz
+        96cad04547f0a32687a92d82f2bf8d256ade93cd1ac43373e189edc79dff12bc  aqua_darwin_arm64.tar.gz
+        4f33be343873ace8fa448193c4e00f9c2bd467daa34abbdb2c3a57aa344bc43d  aqua_linux_amd64.tar.gz
+        a929dad9cc6c841aff02712392a5d4898d7d935f5085ccfaaf637d6784aab28a  aqua_linux_arm64.tar.gz
+        fe6bfe3ae93cb4715b3887e3c595d066a1c696a2852d9efa649487db609df31f  aqua_windows_amd64.zip
+        c34dc6e0329c5e693f125b1285b137589bd8783ff57ce36219ad63f6e1665ae0  aqua_windows_arm64.zip"
 
         filename=aqua_${OS}_${ARCH}.tar.gz
         if [ "$OS" = windows ]; then

--- a/src/commands/aqua.yml
+++ b/src/commands/aqua.yml
@@ -74,8 +74,6 @@ steps:
         ALL: << parameters.aqua_all >>
         TAGS: << parameters.aqua_tags >>
         EXCLUDE_TAGS: << parameters.aqua_exclude_tags >>
-        AQUA_DISABLE_COSIGN: "true"
-        AQUA_DISABLE_SLSA: "true"
       command: |
         set -eu
         set -o pipefail || :
@@ -134,13 +132,13 @@ steps:
           install_path=${AQUA_ROOT_DIR:-$HOME/AppData/Local/aquaproj-aqua}/bin/aqua.exe
         fi
 
-        bootstrap_version=v2.25.0
-        checksums="c9b6e0422ae832b06e82db11f28f6c8507dc1325194bd7a88439a6a09c763c8d  aqua_darwin_amd64.tar.gz
-        3519f47525727cc52b545d50eaaeedb29fe7689c02a8da2096edda43d9ae89b8  aqua_darwin_arm64.tar.gz
-        f62f1d7ba1b7ec6eccdca05c4da718f0935cdfabadd5aa822cab62f2b42daa93  aqua_linux_amd64.tar.gz
-        8eb28b38233c2c4f6cad5af326b1cf1fc084a42fd06eb7d426f89b756b55bf74  aqua_linux_arm64.tar.gz
-        0f402af4eb8b50e0d2fc6d604119c76c8af2dac1a99eeb4655fdc515452c8151  aqua_windows_amd64.zip
-        a3440206c0f6126d0c6be8c491bb26fe46f060431ea111d9d58c41e6b313a7f3  aqua_windows_arm64.zip"
+        bootstrap_version=v2.25.1-5
+        checksums="26b89ce022795b25e342f14d2ee1cdacdde0d57d1650b403e48938b917d84645  aqua_darwin_amd64.tar.gz
+        e9a59d4ce33327f72027786c39f2b60ba33683cf89fc48e6231beaf482b59e6d  aqua_darwin_arm64.tar.gz
+        bcb35348205f572bfb310e0cc9bd5279166754447e83acec17de9b289bf0c2a1  aqua_linux_amd64.tar.gz
+        8ff03737b43ed63bc9bccb36c5957fff62f93f23f18d523bf715e3b5732a3eb9  aqua_linux_arm64.tar.gz
+        10d8662b13531d3c04f295ab65808a0fa4a629af453444159659dc318ea3f0f8  aqua_windows_amd64.zip
+        88b50806832d7a0ded5cbc4d2eca9c22f9e19e06ef2f7ce76a47fbd8f0be7ce8  aqua_windows_arm64.zip"
 
         filename=aqua_${OS}_${ARCH}.tar.gz
         if [ "$OS" = windows ]; then

--- a/src/commands/update-checksum.yml
+++ b/src/commands/update-checksum.yml
@@ -63,8 +63,6 @@ steps:
         PRUNE: << parameters.prune >>
         ROOT_DIRECTORY: << parameters.git_root_directory >>
         WORKING_DIRECTORY: << parameters.working_directory >>
-        AQUA_DISABLE_COSIGN: "true"
-        AQUA_DISABLE_SLSA: "true"
       command: |
         set -euo pipefail
 


### PR DESCRIPTION
## ⚠️ Breaking Changes

update-checksum: The verification with Cosign and slsa-verifier are re-enabled.
Please upgrade aqua to v2.25.1 or later.