### PR TITLE
Update bootstrap version to v2.51.2

### DIFF
--- a/src/commands/aqua.yml
+++ b/src/commands/aqua.yml
@@ -132,13 +132,13 @@ steps:
           install_path=${AQUA_ROOT_DIR:-$HOME/AppData/Local/aquaproj-aqua}/bin/aqua.exe
         fi
 
-        bootstrap_version=v2.27.4
-        checksums="fa04116332b454f9e06020a0afb1fa87c7cda46d2e1e97fd3d9fd93a46cec1e4  aqua_darwin_amd64.tar.gz
-        3190f8d9d1655e65322f396ae2eb493257a8df0c4ec2e4cf221c6e72bb7a4452  aqua_darwin_arm64.tar.gz
-        0e6be7a87a5466fe3b236e1909904b0407a5d8b5ce3035f1f5a108ff8f3869e8  aqua_linux_amd64.tar.gz
-        60361a4c41491f1c3a5615eb14fffa0a2f2b907bbe920a58a7fd44d840ae8941  aqua_linux_arm64.tar.gz
-        444e9da7249b456def5ac2eee9a42fee86d5e74f1a883a3c8748a36c1c857392  aqua_windows_amd64.zip
-        eb4032e839c345677b1e86552c6693fe6e6a05c669ecb3882b7d5a4df45c0dcd  aqua_windows_arm64.zip"
+        bootstrap_version=v2.51.2
+        checksums="ccca5f1c6473aa1fe67f84b244656290ac72e26998ef3479e00843b6b3e52650  aqua_darwin_amd64.tar.gz
+        4ff9a263f6125369b391d37ad6593a8b987aae672c311f61859c4db986732357  aqua_darwin_arm64.tar.gz
+        17db2da427bde293b1942e3220675ef796a67f1207daf89e6e80fea8d2bb8c22  aqua_linux_amd64.tar.gz
+        b3f0d573e762ce9d104c671b8224506c4c4a32eedd1e6d7ae1e1e39983cdb6a8  aqua_linux_arm64.tar.gz
+        bcac8677b632009ba9b561d38dddb0e07c55c5ac4690e0deb1a24b9e0cf282c8  aqua_windows_amd64.zip
+        3d76eaaf9211aeb6186f1829ff21930a798a45163fac58c4ab5aa753a3220616  aqua_windows_arm64.zip"
 
         filename=aqua_${OS}_${ARCH}.tar.gz
         if [ "$OS" = windows ]; then


### PR DESCRIPTION
## Problem

Installation of aqua v2.51.2 via Orb fails.

## Reproduction

The issue was reproduced in a Docker container on a local environment.  
I extracted the step "Install aqua" from `src/commands/aqua.yml` as a standalone shell script and executed it.

<details>
<summary>install-aqua.sh</summary>

```bash
#!/bin/bash

set -eu
set -o pipefail || :

AQUA_VERSION=v2.51.2
POLICY_ALLOW=true
ENABLE_AQUA_INSTALL=true
WORKING_DIRECTORY=.
LOG_LEVEL=debug
CONFIG=""
ONLY_LINK=true
ALL=false
TAGS=""
EXCLUDE_TAGS=""

BASH_ENV=/tmp/.bashrc

uname_os() {
    local os
    os=$(uname -s | tr '[:upper:]' '[:lower:]')
    case "$os" in
    cygwin_nt*) os="windows" ;;
    mingw*) os="windows" ;;
    msys_nt*) os="windows" ;;
    esac
    echo "$os"
}

uname_arch() {
    local arch
    arch=$(uname -m)
    case $arch in
    x86_64) arch="amd64" ;;
    aarch64) arch="arm64" ;;
    esac
    echo ${arch}
}

is_true() {
    val=$1
    [ "$val" = true ] || [ "$val" = True ] || [ "$val" = y ] || [ "$val" = yes ] || [ "$val" = on ] || [ "$val" = 1 ]
}

if [ -n "$LOG_LEVEL" ]; then
    export "AQUA_LOG_LEVEL=$LOG_LEVEL"
fi
if [ -n "$CONFIG" ]; then
    export "AQUA_CONFIG=$CONFIG"
fi
opts=""
if is_true "$ONLY_LINK"; then
    opts=-l
fi
if is_true "$ALL"; then
    opts="-a $opts"
fi
if [ -n "$TAGS" ]; then
    opts="-t \"$TAGS\" $opts"
fi
if [ -n "$EXCLUDE_TAGS" ]; then
    opts="-exclude-tags \"$EXCLUDE_TAGS\" $opts"
fi

OS="$(uname_os)"
ARCH="$(uname_arch)"

install_path=${AQUA_ROOT_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/aquaproj-aqua}/bin/aqua
if [ "$OS" = windows ]; then
    install_path=${AQUA_ROOT_DIR:-$HOME/AppData/Local/aquaproj-aqua}/bin/aqua.exe
fi

bootstrap_version=v2.27.4
checksums="fa04116332b454f9e06020a0afb1fa87c7cda46d2e1e97fd3d9fd93a46cec1e4  aqua_darwin_amd64.tar.gz
3190f8d9d1655e65322f396ae2eb493257a8df0c4ec2e4cf221c6e72bb7a4452  aqua_darwin_arm64.tar.gz
0e6be7a87a5466fe3b236e1909904b0407a5d8b5ce3035f1f5a108ff8f3869e8  aqua_linux_amd64.tar.gz
60361a4c41491f1c3a5615eb14fffa0a2f2b907bbe920a58a7fd44d840ae8941  aqua_linux_arm64.tar.gz
444e9da7249b456def5ac2eee9a42fee86d5e74f1a883a3c8748a36c1c857392  aqua_windows_amd64.zip
eb4032e839c345677b1e86552c6693fe6e6a05c669ecb3882b7d5a4df45c0dcd  aqua_windows_arm64.zip"

filename=aqua_${OS}_${ARCH}.tar.gz
if [ "$OS" = windows ]; then
   	filename=aqua_${OS}_${ARCH}.zip
fi
URL=https://github.com/aquaproj/aqua/releases/download/$bootstrap_version/$filename

tempdir=$(mktemp -d)
echo "[INFO] Installing aqua $bootstrap_version for bootstrapping..." >&2
echo "[INFO] Downloading $URL ..." >&2
if command -v curl > /dev/null 2>&1; then
   	curl --fail -L "$URL" -o "$tempdir/$filename"
elif command -v wget > /dev/null 2>&1; then
   	wget -P "$tempdir" "$URL"
else
   	echo "[ERROR] Neither curl nor wget is found. Please install either curl or wget to download aqua" >&2
   	exit 1
fi

pwd=$PWD
cd "$tempdir"

echo "[INFO] Verifying checksum of aqua $bootstrap_version ..." >&2
if command -v sha256sum > /dev/null 2>&1; then
    echo "$checksums" | grep "$filename" | sha256sum -c
elif command -v shasum > /dev/null 2>&1; then
    echo "$checksums" | grep "$filename" | shasum -a 256 -c
else
   	echo "Skipped checksum verification of aqua $bootstrap_version, because both sha256sum and shasum aren't found" >&2
fi

if [ "$OS" = windows ]; then
   	unzip "$filename" > /dev/null
else
   	tar xvzf "$filename" > /dev/null
fi
chmod a+x aqua

export "PATH=$(./aqua root-dir)/bin::$PATH"
echo "export \"PATH=$(./aqua root-dir)/bin:$PATH\"" >> "$BASH_ENV"
if [ "$OS" = windows ]; then
    export "PATH=$(./aqua root-dir)/bat:$PATH"
    echo "export \"PATH=$(./aqua root-dir)/bat:$PATH\"" >> "$BASH_ENV"
fi

echo "[INFO] $tempdir/aqua update-aqua $AQUA_VERSION" >&2
./aqua update-aqua "$AQUA_VERSION"

cd "$pwd/$WORKING_DIRECTORY"
rm -R "$tempdir"

if [ "$POLICY_ALLOW" = true ]; then
    echo "[INFO] aqua policy allow" >&2
    aqua policy allow
    exit 0
fi
if [ -n "$POLICY_ALLOW" ]; then
    echo '[INFO] aqua policy allow $POLICY_ALLOW' >&2
    aqua policy allow "$POLICY_ALLOW"
fi

if is_true "$ENABLE_AQUA_INSTALL"; then
    echo "aqua i $opts" >&2
    aqua i $opts
fi
```

</details> 

The result of the execution is as follows:

```console
$ docker run -it -v $(pwd)/install-aqua.sh:/tmp/install-aqua.sh cimg/base:24.04 /tmp/install-aqua.sh
[INFO] Installing aqua v2.27.4 for bootstrapping...
[INFO] Downloading https://github.com/aquaproj/aqua/releases/download/v2.27.4/aqua_linux_arm64.tar.gz ...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 6195k  100 6195k    0     0  9798k      0 --:--:-- --:--:-- --:--:-- 9798k
[INFO] Verifying checksum of aqua v2.27.4 ...
aqua_linux_arm64.tar.gz: OK
[INFO] /tmp/tmp.y6Jlvf2cFb/aqua update-aqua v2.51.2
DEBU[0000] match the version_constraint                  aqua_version=2.27.4 env=linux/arm64 new_version=v2.51.2 package_semver=v2.51.2 package_version=v2.51.2 program=aqua version_constraint="semver(\">= 2.17.0\")"
DEBU[0000] installing the package                        aqua_version=2.27.4 env=linux/arm64 new_version=v2.51.2 package_name=aquaproj/aqua package_version=v2.51.2 program=aqua registry=
DEBU[0000] check if the package is already installed     aqua_version=2.27.4 env=linux/arm64 new_version=v2.51.2 package_name=aquaproj/aqua package_version=v2.51.2 program=aqua registry=
INFO[0000] download and unarchive the package            aqua_version=2.27.4 env=linux/arm64 new_version=v2.51.2 package_name=aquaproj/aqua package_version=v2.51.2 program=aqua registry=
INFO[0001] verify a package with slsa-verifier           aqua_version=2.27.4 env=linux/arm64 new_version=v2.51.2 package_name=aquaproj/aqua package_version=v2.51.2 program=aqua registry=
DEBU[0001] no version_constraint                         aqua_version=2.27.4 env=linux/arm64 new_version=v2.51.2 package_name=aquaproj/aqua package_version=v2.51.2 program=aqua registry=
DEBU[0001] installing the package                        aqua_version=2.27.4 env=linux/arm64 new_version=v2.51.2 package_name=slsa-framework/slsa-verifier package_version=v2.5.1 program=aqua registry=
DEBU[0001] check if the package is already installed     aqua_version=2.27.4 env=linux/arm64 new_version=v2.51.2 package_name=slsa-framework/slsa-verifier package_version=v2.5.1 program=aqua registry=
INFO[0001] download and unarchive the package            aqua_version=2.27.4 env=linux/arm64 new_version=v2.51.2 package_name=slsa-framework/slsa-verifier package_version=v2.5.1 program=aqua registry=
DEBU[0002] check the permission                          aqua_version=2.27.4 env=linux/arm64 file_name=slsa-verifier new_version=v2.51.2 package_name=slsa-framework/slsa-verifier package_version=v2.5.1 program=aqua registry=
No certificate provided, trying Redis search index to find entries by subject digest
Verifying artifact /tmp/678032998: FAILED: could not find a matching valid signature entry: got unexpected errors invalid signature: no signature found, invalid signature: no signature found

FAILED: SLSA verification failed: could not find a matching valid signature entry: got unexpected errors invalid signature: no signature found, invalid signature: no signature found
INFO[0004] Verification by slsa-verifier failed temporarily, retring  aqua_version=2.27.4 env=linux/arm64 new_version=v2.51.2 package_name=aquaproj/aqua package_version=v2.51.2 program=aqua registry= retry_count=1 wait_time=805ms
No certificate provided, trying Redis search index to find entries by subject digest
Verifying artifact /tmp/678032998: FAILED: could not find a matching valid signature entry: got unexpected errors invalid signature: no signature found, invalid signature: no signature found

FAILED: SLSA verification failed: could not find a matching valid signature entry: got unexpected errors invalid signature: no signature found, invalid signature: no signature found
INFO[0005] Verification by slsa-verifier failed temporarily, retring  aqua_version=2.27.4 env=linux/arm64 new_version=v2.51.2 package_name=aquaproj/aqua package_version=v2.51.2 program=aqua registry= retry_count=2 wait_time=9ms
No certificate provided, trying Redis search index to find entries by subject digest
Verifying artifact /tmp/678032998: FAILED: could not find a matching valid signature entry: got unexpected errors invalid signature: no signature found, invalid signature: no signature found

FAILED: SLSA verification failed: could not find a matching valid signature entry: got unexpected errors invalid signature: no signature found, invalid signature: no signature found
INFO[0006] Verification by slsa-verifier failed temporarily, retring  aqua_version=2.27.4 env=linux/arm64 new_version=v2.51.2 package_name=aquaproj/aqua package_version=v2.51.2 program=aqua registry= retry_count=3 wait_time=739ms
No certificate provided, trying Redis search index to find entries by subject digest
Verifying artifact /tmp/678032998: FAILED: could not find a matching valid signature entry: got unexpected errors invalid signature: no signature found, invalid signature: no signature found

FAILED: SLSA verification failed: could not find a matching valid signature entry: got unexpected errors invalid signature: no signature found, invalid signature: no signature found
INFO[0008] Verification by slsa-verifier failed temporarily, retring  aqua_version=2.27.4 env=linux/arm64 new_version=v2.51.2 package_name=aquaproj/aqua package_version=v2.51.2 program=aqua registry= retry_count=4 wait_time=173ms
No certificate provided, trying Redis search index to find entries by subject digest
Verifying artifact /tmp/678032998: FAILED: could not find a matching valid signature entry: got unexpected errors invalid signature: no signature found, invalid signature: no signature found

FAILED: SLSA verification failed: could not find a matching valid signature entry: got unexpected errors invalid signature: no signature found, invalid signature: no signature found
FATA[0009] aqua failed                                   aqua_version=2.27.4 env=linux/arm64 error="download aqua: verify a package with slsa-verifier: verify with slsa-verifier" new_version=v2.51.2 program=aqua
```

## Solution

The problem was resolved by updating the version of aqua used for bootstrapping to the latest version, v2.51.2.

```console
$ docker run -it -v $(pwd)/install-aqua.sh:/tmp/install-aqua.sh cimg/base:24.04 /tmp/install-aqua.sh
[INFO] Installing aqua v2.51.2 for bootstrapping...
[INFO] Downloading https://github.com/aquaproj/aqua/releases/download/v2.51.2/aqua_linux_arm64.tar.gz ...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 7318k  100 7318k    0     0  6352k      0  0:00:01  0:00:01 --:--:-- 55.4M
[INFO] Verifying checksum of aqua v2.51.2 ...
aqua_linux_arm64.tar.gz: OK
[INFO] /tmp/tmp.M8RogSP3zq/aqua update-aqua v2.51.2
DEBU[0000] no version_constraint matches                 aqua_version=2.51.2 env=linux/arm64 package_version=0.12 program=aqua version_constraint=false
DEBU[0000] the package isn't supported in the environment  aqua_version=2.51.2 env=linux/arm64 program=aqua
DEBU[0000] match the version_constraint                  aqua_version=2.51.2 env=linux/arm64 new_version=v2.51.2 package_semver=v2.51.2 package_version=v2.51.2 program=aqua version_constraint="semver(\">= 2.17.0\")"
DEBU[0000] installing the package                        aqua_version=2.51.2 env=linux/arm64 new_version=v2.51.2 package_name=aquaproj/aqua package_version=v2.51.2 program=aqua registry=
DEBU[0000] check if the package is already installed     aqua_version=2.51.2 env=linux/arm64 new_version=v2.51.2 package_name=aquaproj/aqua package_version=v2.51.2 program=aqua registry=
INFO[0000] download and unarchive the package            aqua_version=2.51.2 env=linux/arm64 new_version=v2.51.2 package_name=aquaproj/aqua package_version=v2.51.2 program=aqua registry=
INFO[0001] verify a package with slsa-verifier           aqua_version=2.51.2 env=linux/arm64 new_version=v2.51.2 package_name=aquaproj/aqua package_version=v2.51.2 program=aqua registry=
DEBU[0001] no version_constraint                         aqua_version=2.51.2 env=linux/arm64 new_version=v2.51.2 package_name=slsa-framework/slsa-verifier package_version=v2.7.0 program=aqua registry=
DEBU[0001] installing the package                        aqua_version=2.51.2 env=linux/arm64 new_version=v2.51.2 package_name=slsa-framework/slsa-verifier package_version=v2.7.0 program=aqua registry=
DEBU[0001] check if the package is already installed     aqua_version=2.51.2 env=linux/arm64 new_version=v2.51.2 package_name=slsa-framework/slsa-verifier package_version=v2.7.0 program=aqua registry=
INFO[0001] download and unarchive the package            aqua_version=2.51.2 env=linux/arm64 new_version=v2.51.2 package_name=slsa-framework/slsa-verifier package_version=v2.7.0 program=aqua registry=
DEBU[0002] check the permission                          aqua_version=2.51.2 env=linux/arm64 file_name=slsa-verifier new_version=v2.51.2 package_name=slsa-framework/slsa-verifier package_version=v2.7.0 program=aqua registry=
Verified build using builder "https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@refs/tags/v2.1.0" at commit dabac1b2572231e6183b2e74ab97508cff56e860
Verifying artifact /tmp/230666947: PASSED

PASSED: SLSA verification passed
DEBU[0004] set a calculated checksum                     aqua_version=2.51.2 checksum=b3f0d573e762ce9d104c671b8224506c4c4a32eedd1e6d7ae1e1e39983cdb6a8 checksum_id=github_release/github.com/aquaproj/aqua/v2.51.2/aqua_linux_arm64.tar.gz env=linux/arm64 new_version=v2.51.2 package_name=aquaproj/aqua package_version=v2.51.2 program=aqua registry=
DEBU[0004] check the permission                          aqua_version=2.51.2 env=linux/arm64 file_name=aqua new_version=v2.51.2 package_name=aquaproj/aqua package_version=v2.51.2 program=aqua registry=
INFO[0004] create a symbolic link                        aqua_version=2.51.2 env=linux/arm64 new_version=v2.51.2 package_name=aquaproj/aqua package_version=v2.51.2 program=aqua
[INFO] aqua policy allow
INFO[0000] no policy file is found                       aqua_version=2.51.2 env=linux/arm64 program=aqua
```
